### PR TITLE
Fix updating of non-plain objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@
 
 var toPath = require('to-object-path');
 var extend = require('extend-shallow');
-var isObject = require('isobject');
+var isObject = require('is-plain-object');
 
 module.exports = function(obj, path, val) {
   if (typeof obj !== 'object') {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "extend-shallow": "^2.0.1",
-    "isobject": "^2.0.0",
+    "is-plain-object": "^2.0.1",
     "to-object-path": "^0.2.0"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -113,6 +113,21 @@ describe('set', function() {
   it('should set a value only.', function () {
     set({a: 'a', b: {c: 'd'}}, 'b.c').should.eql({a: 'a', b: {c: undefined}});
   });
+
+  it('should set non-plain objects', function (done) {
+    var o = {};
+
+    set(o, 'a.b', new Date());
+    var firstDate = o.a.b.getTime();
+
+    setTimeout(function () {
+      set(o, 'a.b', new Date());
+      var secondDate = o.a.b.getTime();
+
+      firstDate.should.not.eql(secondDate);
+      done();
+    }, 10);
+  });
 });
 
 describe('escaping', function () {


### PR DESCRIPTION
This PR fixes #5, as I recently faced exact same issue.

In my case, `set-value` did not update `Date` object:

```js
var set = require('set-value');

var obj = {};

set(obj, 'a.b', new Date());
// { a: { b: 2016-09-05T13:46:17.043Z } }

set(obj, 'a.b', new Date());
// { a: { b: 2016-09-05T13:46:17.043Z } }
```

The date in `a.b` property remains the same, but should be replaced. This is caused by https://github.com/jonschlinkert/set-value/blob/master/index.js#L51-L52, which identifies `Date` as an object (which it is, ofc), but instead of replacing the property value, it extends the props.

The fix is simple, replace `isobject` dependency with `is-plain-obj`. Also added a test to ensure this issue won't pop up again.