### PR TITLE
Remove sudo settings from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 os:
   - linux
   - osx


### PR DESCRIPTION
'sudo' seems to be unavailable.
Remove sudo settings from .travis.yml

https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration