### PR TITLE
Fix incorrect behavior for keys ending with a dot

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ function split(path, options) {
 
   for (let i = 0; i < keys.length; i++) {
     let prop = keys[i];
-    while (prop && prop.slice(-1) === '\\' && keys[i + 1]) {
+    while (prop && prop.slice(-1) === '\\' && keys[i + 1] != null) {
       prop = prop.slice(0, -1) + char + keys[++i];
     }
     res.push(prop);


### PR DESCRIPTION
If the key ends with a dot, then the last element in the "keys" array is an empty string - this causes the condition of the while-loop to evaluate to false. Due to this, a second (empty) element is pushed to "res" array. Comparing the next value of the "keys" array with null/undefined fixes this.


Fixes doowb/group-array#11