### PR TITLE
add support for array creation

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,9 @@ function set(target, path, value, options) {
     let prop = keys[i];
 
     if (!isObject(target[prop])) {
-      target[prop] = {};
+      let nextProp = i + 1 < len ? keys[i + 1] : "";
+      let shouldBeArray = !isNaN(+nextProp);
+      target[prop] = shouldBeArray ? [] : {};
     }
 
     if (i === len - 1) {

--- a/test.js
+++ b/test.js
@@ -26,6 +26,17 @@ describe('set', function() {
     assert.equal(o.a.b, 'c');
   });
 
+  it('should create a nested array if it does not already exist', function() {
+    const o = {};
+    set(o, 'a.0', 'c');
+    set(o, 'a.1', 'd');
+    assert(Array.isArray(o.a));
+    assert.equal(o.a[0], 'c');
+    let actual = "";
+    o.a.map(i=> actual +=i);
+    assert.equal(actual, "cd");
+  });
+
   it('should merge an existing value with the given value', function() {
     var o = {a: {b: {c: 'd'}}};
     set(o, 'a.b', {y: 'z'}, { merge: true });


### PR DESCRIPTION
The current implementation always creates objects.

Added support for array creation for paths like a.0.

Example: set({}, 'a.0', 42)
Previous implementation would make "a" an Object with a property named "0" set to the number 42.
New implementation makes "a" and Array with the first element set to the number 42.

Should fix: https://github.com/jonschlinkert/set-value/issues/19