### PR TITLE
swap missing parent assignment of {} to after last target check to av…

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,13 +37,13 @@ function set(target, path, value, options) {
   for (let i = 0; i < len; i++) {
     let prop = keys[i];
 
-    if (!isObject(target[prop])) {
-      target[prop] = {};
-    }
-
     if (i === len - 1) {
       result(target, prop, value, merge);
       break;
+    }
+
+    if (!isObject(target[prop])) {
+      target[prop] = {};
     }
 
     target = target[prop];

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "test": "mocha"
   },
   "dependencies": {
-    "is-plain-object": "^2.0.4"
+    "is-plain-object": "^2.0.4",
+    "rxjs": "^6.5.5"
   },
   "devDependencies": {
     "benchmarked": "^2.0.0",

--- a/test.js
+++ b/test.js
@@ -188,25 +188,91 @@ describe('options', function() {
 
   it('should use a custom function to not split inside square brackets', function() {
     var o = {};
-    set(o, "a.[b.c.d].e", 'c', options);
+    set(o, 'a.[b.c.d].e', 'c', options);
     assert.equal(o.a['[b.c.d]'].e, 'c');
   });
 
   it('should use a custom function to not split inside parens', function() {
     var o = {};
-    set(o, "a.(b.c.d).e", 'c', options);
+    set(o, 'a.(b.c.d).e', 'c', options);
     assert.equal(o.a['(b.c.d)'].e, 'c');
   });
 
   it('should use a custom function to not split inside angle brackets', function() {
     var o = {};
-    set(o, "a.<b.c.d>.e", 'c', options);
+    set(o, 'a.<b.c.d>.e', 'c', options);
     assert.equal(o.a['<b.c.d>'].e, 'c');
   });
 
   it('should use a custom function to not split inside curly braces', function() {
     var o = {};
-    set(o, "a.{b.c.d}.e", 'c', options);
+    set(o, 'a.{b.c.d}.e', 'c', options);
     assert.equal(o.a['{b.c.d}'].e, 'c');
   });
+});
+
+const Rx = require('rxjs');
+const opers = require('rxjs/operators');
+
+var _value = 0;
+var o = {a: { b: {} } };
+var obs = Rx.from(new Rx.BehaviorSubject()).pipe(
+  opers.skip(1),
+);
+
+Object.defineProperty(o.a.b, 'c', {
+  configurable: true,
+  get() { return _value; },
+  set(value) {
+    _value = value;
+    obs.next(value);
+  }
+});
+
+describe('Setter with Observable', function() {
+  // const expected = 11;
+  var received = [];
+  const noop = () => {};
+  it('should only assign/emit once for each call of set', function(done) {
+    var subs = obs.subscribe(
+      data => { received.push(data); },
+      noop,
+      () => {
+        assert.equal(received.length, 1);
+        done();
+      }
+    );
+    set(o, 'a.b.c', 5);
+    subs.complete();
+  });
+
+  it('should work assignment via setter', function(done) {
+    received = null;
+    var subs = obs.subscribe(
+      data => { received = data; },
+      noop,
+      () => {
+        assert.equal(received, 10);
+        done();
+      }
+    );
+    set(o, 'a.b.c', 10);
+    subs.complete();
+  });
+
+  it('should work with merge of object via setter', function(done) {
+    received = null;
+    set(o, 'a.b.c', {foo: 'bar'});
+    var subs = obs.subscribe(
+      data => { received = data; },
+      noop,
+      () => {
+        assert.deepEqual(o.a.b.c, { foo: 'bar', bing: 'bong' });
+        done();
+      }
+    );
+    set(o, 'a.b.c', { bing: 'bong'}, {merge: true});
+    subs.complete();
+  });
+
 });


### PR DESCRIPTION
Here it be.  I added three tests to that use a setter and observable and it passes all of those and your tests as long as the that parent assignement is after the break.   Just swap those back and you will fail the test

BTW there was no issue with the merge option.  (included a test for that).

-------

Also I think you should include documentation readme for the currently undocumented options, (i.e. merge/function,split/separator)   

FYI I have a bit more robust handler for variations of the path format.  Handles also multiple delimiters.  I just call before calling set it might be nice to incorporate directly to avoid unnecessary joining and splitting.  Let me know if that is something you want to include and I'll make a pr for that.