### PR TITLE
Add setUndefined option

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,25 @@ set(obj, 'foo.bar.fez', 'zzz', { merge: true });
 //=> { foo: { bar: { baz: 'qux', fez: 'zzz' } } }
 ```
 
+### options.setUndefined
+
+Set the value to undefined instead of deleting the property when the value is undefined.
+
+**Type**: `boolean`
+
+**Default**: `false`
+
+**Example**
+
+```js
+console.log(set({foo: 'bar', baz: 'foo'}, 'foo', undefined, { setUndefined:  false }));
+//=> { baz: 'foo' }
+
+console.log(set({foo: 'bar', baz: 'foo'}, 'foo', undefined, { setUndefined:  true }));
+//=> { foo: undefined, baz: 'foo' }
+```
+
+
 ## Benchmarks
 
 Benchmarks were run on a MacBook Pro 2.5 GHz Intel Core i7, 16 GB 1600 MHz DDR3.
@@ -271,18 +290,18 @@ You might also be interested in these projects:
 
 ### Contributors
 
-| **Commits** | **Contributor** |  
-| --- | --- |  
-| 87 | [jonschlinkert](https://github.com/jonschlinkert) |  
-| 4  | [doowb](https://github.com/doowb) |  
-| 2  | [mbelsky](https://github.com/mbelsky) |  
-| 1  | [dkebler](https://github.com/dkebler) |  
-| 1  | [GlennKintscher](https://github.com/GlennKintscher) |  
-| 1  | [petermorlion](https://github.com/petermorlion) |  
-| 1  | [abetomo](https://github.com/abetomo) |  
-| 1  | [zeidoo](https://github.com/zeidoo) |  
-| 1  | [ready-research](https://github.com/ready-research) |  
-| 1  | [wtgtybhertgeghgtwtg](https://github.com/wtgtybhertgeghgtwtg) |  
+| **Commits** | **Contributor** |
+| --- | --- |
+| 87 | [jonschlinkert](https://github.com/jonschlinkert) |
+| 4  | [doowb](https://github.com/doowb) |
+| 2  | [mbelsky](https://github.com/mbelsky) |
+| 1  | [dkebler](https://github.com/dkebler) |
+| 1  | [GlennKintscher](https://github.com/GlennKintscher) |
+| 1  | [petermorlion](https://github.com/petermorlion) |
+| 1  | [abetomo](https://github.com/abetomo) |
+| 1  | [zeidoo](https://github.com/zeidoo) |
+| 1  | [ready-research](https://github.com/ready-research) |
+| 1  | [wtgtybhertgeghgtwtg](https://github.com/wtgtybhertgeghgtwtg) |
 
 ### Author
 

--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ You might also be interested in these projects:
 | 1  | [zeidoo](https://github.com/zeidoo) |
 | 1  | [ready-research](https://github.com/ready-research) |
 | 1  | [wtgtybhertgeghgtwtg](https://github.com/wtgtybhertgeghgtwtg) |
+| 1  | [snowbldr](https://github.com/snowbldr) |
 
 ### Author
 

--- a/index.js
+++ b/index.js
@@ -107,8 +107,8 @@ const split = (input, options) => {
 const assignProp = (obj, prop, value, options) => {
   validateKey(prop);
 
-  // Delete property when "value" is undefined
-  if (value === undefined) {
+  // Delete property when "value" is undefined and setUndefined is falsey
+  if (value === undefined && (!options || !options.setUndefined)) {
     deleteProperty(obj, prop);
 
   } else if (options && options.merge) {

--- a/test/test.js
+++ b/test/test.js
@@ -159,6 +159,29 @@ describe('set-value', () => {
       assert.deepEqual(set({ a: 'a', b: { c: 'd' } }, 'b.c'), { a: 'a', b: {} });
     });
 
+    it('should delete the property undefined when setUndefined is false', () => {
+      const fixture = {};
+      assert.deepEqual(set(fixture, 'a.locals.name', undefined, { setUndefined: false }), { a: { locals: {} } });
+      assert.deepEqual(set(fixture, 'b.locals.name', undefined, { setUndefined: false }), { b: { locals: {} }, a: { locals: {} } });
+      assert.deepEqual(set({ a: 'a', b: { c: 'd' } }, 'b.c', undefined, { setUndefined: false }), { a: 'a', b: {} });
+    });
+
+    it('should set the property undefined when setUndefined is true', () => {
+      const fixture = {};
+      assert.deepEqual(
+        set(fixture, 'a.locals.name', undefined, { setUndefined: true }),
+        { a: { locals: {name: undefined} } }
+      );
+      assert.deepEqual(
+        set(fixture, 'b.locals.name', undefined, { setUndefined: true }),
+        { b: { locals: {name: undefined} }, a: { locals: {name: undefined} } }
+      );
+      assert.deepEqual(
+        set({ a: 'a', b: { c: 'd' } }, 'b.c', undefined, { setUndefined: true }),
+        { a: 'a', b: { c: undefined } }
+      );
+    });
+
     it('should return the entire object if no property is passed.', () => {
       assert.deepEqual(set({ a: 'a', b: { c: 'd' } }), { a: 'a', b: { c: 'd' } });
     });


### PR DESCRIPTION
I have a use case where I need to set a value explicitly to undefined. In the current state, it's not possible to use this function to accomplish my goals. 

This PR adds a "setUndefined" option that allows altering the default behavior such that undefined values will be set explicitly on the object instead of deleting the property. 

This is false by default which preserves the current default behavior.