### PR TITLE
Fix custom merge function not working

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,7 +112,7 @@ const assignProp = (obj, prop, value, options) => {
     deleteProperty(obj, prop);
 
   } else if (options && options.merge) {
-    const merge = options.merge === 'function' ? options.merge : Object.assign;
+    const merge = typeof options.merge === 'function' ? options.merge : Object.assign;
 
     // Only merge plain objects
     if (merge && isPlainObject(obj[prop]) && isPlainObject(value)) {


### PR DESCRIPTION
Hello

Not sure how no one has noticed that in 2 years but a `typeof` is missing here

https://github.com/jonschlinkert/set-value/blob/c574eb8d94ba21d22b6fe5a5741fd4dbfc9dc47a/index.js#L115

Regression occurred after https://github.com/jonschlinkert/set-value/commit/cdc74463f5778f2c50b1bae839818ac76268aa51#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R115